### PR TITLE
Fix getImageSrc(...) throwing exception

### DIFF
--- a/manup.js
+++ b/manup.js
@@ -166,7 +166,7 @@ class ManUp {
         return imageArray
       }
     })
-    return srcImage[0].src
+    return (srcImage && srcImage.length > 0) ? srcImage[0].src : undefined
   }
 }
 


### PR DESCRIPTION
Fixed getImageSrc(...) throws exception if the array filter is not satisfied